### PR TITLE
invalidateHouseArrestAFCConnectionForBundleID

### DIFF
--- a/FBDeviceControl/Commands/FBDeviceCommands.h
+++ b/FBDeviceControl/Commands/FBDeviceCommands.h
@@ -145,6 +145,13 @@ extern FBDeviceActivationState FBDeviceActivationStateCoerceFromString(NSString 
  */
 - (FBFutureContext<FBAFCConnection *> *)houseArrestAFCConnectionForBundleID:(NSString *)bundleID afcCalls:(AFCCalls)afcCalls;
 
+/**
+ Invalidates house arrest connection for a given bundle id.
+ Does nothing if no connection exists already.
+ This can be used whenever a cached connection returns previously encountered errors on subsequent operations
+ */
+- (void)invalidateHouseArrestAFCConnectionForBundleID:(NSString *)bundleID;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FBDeviceControl/Management/FBAMDevice.m
+++ b/FBDeviceControl/Management/FBAMDevice.m
@@ -224,6 +224,11 @@
     }];
 }
 
+- (void)invalidateHouseArrestAFCConnectionForBundleID:(NSString *)bundleID
+{
+  [self.serviceManager invalidateHouseArrestAFCConnectionForBundleID:bundleID];
+}
+
 #pragma mark FBFutureContextManager Implementation
 
 - (FBFuture<FBAMDevice *> *)prepare:(id<FBControlCoreLogger>)logger

--- a/FBDeviceControl/Management/FBAMDeviceServiceManager.h
+++ b/FBDeviceControl/Management/FBAMDeviceServiceManager.h
@@ -43,6 +43,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (FBFutureContextManager<FBAFCConnection *> *)houseArrestAFCConnectionForBundleID:(NSString *)bundleID afcCalls:(AFCCalls)afcCalls;
 
+
+/**
+ Invalidates house arrest connection for a given bundle id.
+ Does nothing if no connection exists already.
+ This can be used whenever a cached connection returns previously encountered errors on subsequent operations
+ */
+- (void)invalidateHouseArrestAFCConnectionForBundleID:(NSString *)bundleID;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FBDeviceControl/Management/FBAMDeviceServiceManager.m
+++ b/FBDeviceControl/Management/FBAMDeviceServiceManager.m
@@ -131,4 +131,11 @@
   return manager;
 }
 
+- (void)invalidateHouseArrestAFCConnectionForBundleID:(NSString *)bundleID
+{
+  [self.houseArrestManagers removeObjectForKey:bundleID];
+  [self.houseArrestDelegates removeObjectForKey:bundleID];
+}
+
+
 @end

--- a/FBDeviceControl/Management/FBDevice.m
+++ b/FBDeviceControl/Management/FBDevice.m
@@ -311,6 +311,14 @@
     failFutureContext];
 }
 
+- (void)invalidateHouseArrestAFCConnectionForBundleID:(NSString *)bundleID
+{
+  FBAMDevice *amDevice = self.amDevice;
+  if (amDevice) {
+    [amDevice invalidateHouseArrestAFCConnectionForBundleID:bundleID];
+  }
+}
+
 #pragma mark Forwarding
 
 + (NSArray<Class> *)commandResponders


### PR DESCRIPTION
on ios in can happen that a previous failure of a file operation causes the connection to continously respond with the same error. This PR adds a hook to enforce using a new connection. It does not shutdown the previous one though (this is done via a timeout - haven't figured out yet how to abort prior) which means that if this happens to often we get an error for too many started services.

In a way this is a more explicit version of the previously used hack: 
https://github.com/Unity-Technologies/idb/commit/81ff7132ef8b80f59307179bfdbf3df453cab3a0

Curiously, this was never observed on tvOS